### PR TITLE
Fix setspeed command and generating stages bug

### DIFF
--- a/Assets/qkForgetPerspectiveScript.cs
+++ b/Assets/qkForgetPerspectiveScript.cs
@@ -1371,7 +1371,7 @@ public class qkForgetPerspectiveScript : MonoBehaviour {
 			commandl=commandl.Replace("SETSPEED ", "");
 			float temprot;
 			if(float.TryParse(commandl, out temprot)){
-                if(rotationTime > 10f)
+                if(temprot > 10f)
                 {
                     yield return "sendtochaterror The rotation time may not be set higher than 10 seconds!";
                     yield break;

--- a/Assets/qkForgetPerspectiveScript.cs
+++ b/Assets/qkForgetPerspectiveScript.cs
@@ -1227,6 +1227,7 @@ public class qkForgetPerspectiveScript : MonoBehaviour {
 
 		 if(solved || !activated){return;}
 		ticker++;
+		int ct = 0;
 		if(!EnableDelay || ticker == 5)
 		{
 			ticker = 0;
@@ -1244,12 +1245,13 @@ public class qkForgetPerspectiveScript : MonoBehaviour {
             if (newSolves.Count() == 0)
                 return;
 
-            foreach (String d in newSolves) { solvedModules.Add(d); lastCalcStage++; }
+            foreach (String d in newSolves) { solvedModules.Add(d); lastCalcStage++; ct++; }
         }
 		if((!EnableDelay || delayer <= 0) && lastCalcStage >= stageNumber)
 		{
 			delayer = rotationTime*1.5f;
-			Reset();
+			for (int i = 0; i < ct; i++)
+				Reset();
 		}
 	 }
 
@@ -1312,7 +1314,6 @@ public class qkForgetPerspectiveScript : MonoBehaviour {
             	yield return null;
         	}
 			Cube.transform.localEulerAngles = new Vector3(0, 180, 0);
-
 
 			/*duration=2;
 			startRotation = Module.transform.localEulerAngles.x;


### PR DESCRIPTION
The stage gen bug is only something seen on TP. When two mods are solved at the exact same time FP's old updater would just register one stage, so it would be softlocked. I found this of course when doing TP autosolvers.